### PR TITLE
security token is required

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 2,
   "name": "AWS Request Signer",
   "description": "Signs requests to AWS endpoints (using Signature Version 4 signing process)",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "icons": { "16": "icon-16.png",
              "48": "icon-48.png",
              "128": "icon-128.png" },

--- a/src/signer.js
+++ b/src/signer.js
@@ -95,8 +95,6 @@ function valid() {
 	  return false;
   if (!secretaccesskey || secretaccesskey.length === 0)
 	  return false;
-  if (!securitytoken || securitytoken.length === 0)
-	  return false;
   
   return true;
 }


### PR DESCRIPTION
On trying to use the extension in chrome, i noticed that no requests would be sent if the security token was not filled in (but the access key/secret were).
Noticed that the code prevents this from being considered valid, and thus doesn't do anything.

I have changed it so that it treats it as valid now, if the security token is missing. e.g. you are using IAM Access Credentials.

Cheers,
Scott
