### PR TITLE
Allow using URL pattern matching

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 2,
   "name": "AWS Request Signer",
   "description": "Signs requests to AWS endpoints (using Signature Version 4 signing process)",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "icons": { "16": "icon-16.png",
              "48": "icon-48.png",
              "128": "icon-128.png" },

--- a/src/options.html
+++ b/src/options.html
@@ -114,6 +114,15 @@ h1 {
 </tr>
 
 <tr>
+<td>
+<label for="url_pattern">URL Pattern:</label>
+</td>
+<td>
+<input type="text" id="url_pattern"></input>
+</td>
+</tr>
+
+<tr>
 <td colspan=2>
 <input type="radio" name="credentialtype" value="instanceprofile" id="credentialtype_instanceprofile" />
 <label for="credentialtype_instanceprofile">Use instance profile credentials</label>

--- a/src/options.js
+++ b/src/options.js
@@ -11,6 +11,7 @@ function save_options() {
   var securitytoken = document.getElementById('securitytoken').value;
   var credentialtype_instanceprofile = document.getElementById('credentialtype_instanceprofile').checked;
   var credentialtype_explicit = document.getElementById('credentialtype_explicit').checked;
+  var url_pattern = document.getElementById('url_pattern').value;
 
   chrome.storage.sync.set({
 	enabled: enabled,
@@ -20,7 +21,8 @@ function save_options() {
 	secretaccesskey: secretaccesskey,
 	securitytoken: securitytoken,
 	credentialtype_instanceprofile: credentialtype_instanceprofile,
-	credentialtype_explicit: credentialtype_explicit
+	credentialtype_explicit: credentialtype_explicit,
+  url_pattern: url_pattern
   }, function() {
     var status = document.getElementById('status');
     status.textContent = 'Options saved.';
@@ -39,7 +41,8 @@ function restore_options() {
 	secretaccesskey: '',
 	securitytoken: '',
 	credentialtype_instanceprofile: true,
-	credentialtype_explicit: false
+	credentialtype_explicit: false,
+  url_pattern: ''
   }, function(items) {
 	document.getElementById('enabled').checked = items.enabled;
 	document.getElementById('region').value = items.region;
@@ -49,6 +52,7 @@ function restore_options() {
 	document.getElementById('securitytoken').value = items.securitytoken;
 	document.getElementById('credentialtype_instanceprofile').checked = items.credentialtype_instanceprofile;
 	document.getElementById('credentialtype_explicit').checked = items.credentialtype_explicit;
+  document.getElementById('url_pattern').value = items.url_pattern;
 	toggle_credential_inputs(items.credentialtype_instanceprofile);
   });
 }

--- a/src/signer.js
+++ b/src/signer.js
@@ -11,6 +11,7 @@ var secretaccesskey = '';
 var securitytoken = '';
 var credentialtype_instanceprofile = false;
 var credentialtype_explicit = false;
+var url_pattern = '';
 
 var instanceprofilecredentialscached = false;
 var instanceprofilecredentialsexpiry;
@@ -24,7 +25,8 @@ function getsettings() {
 		secretaccesskey: '',
 		securitytoken: '',
 		credentialtype_instanceprofile: true,
-		credentialtype_explicit: false
+		credentialtype_explicit: false,
+    url_pattern: ''
 		}, function(items) {
 			enabled = items.enabled;
 			region = items.region;
@@ -34,6 +36,7 @@ function getsettings() {
 			securitytoken = items.securitytoken;
 			credentialtype_instanceprofile = items.credentialtype_instanceprofile;
 			credentialtype_explicit = items.credentialtype_explicit;
+      url_pattern = items.url_pattern;
 			
 			updateicon();
 			if (credentialtype_instanceprofile)
@@ -60,6 +63,9 @@ chrome.webRequest.onBeforeRequest.addListener(
 	  if (!enabled || !valid())
 		  return;
 
+    if (url_pattern && !details.url.match(url_pattern))
+      return;
+
 	  var hashedPayload = getHashedPayload(details);
 	  hashedPayloads[details.requestId] = hashedPayload;
 	  log('Hashed Payload: ' + hashedPayload);
@@ -76,6 +82,9 @@ chrome.webRequest.onBeforeSendHeaders.addListener(
 	  if (!enabled || !valid())
 		  return;
  
+    if (url_pattern && !details.url.match(url_pattern))
+      return;
+
 	  var authedHeaders = signRequest(details);
 	  delete hashedPayloads[details.requestId];
  


### PR DESCRIPTION
This is a very useful tool. We used it to access our Kibana server that comes with the AWS elasticsearch. One annoying thing I found is that we cannot access CloudWatch log when we enable the extension because it adds the authentication header for that part as well. 

So to bypass the problem, I created this PR. It simply allow a new option for URL pattern and calls `String.match` before signing the request.