### PR TITLE
Handle all chars that need to be encoded

### DIFF
--- a/src/signer.js
+++ b/src/signer.js
@@ -266,10 +266,8 @@ function getCanonicalUri(url) {
 	  uri = '/';
   else if (uri.substr(0,1) !== '/')
 	  uri = '/' + uri;
-  
-  // aws wants asterisk encoded
-  uri = uri.replace(/\*/g, '%2A');
-  return uri;
+
+  return uriEncode(uri);
 }
 function getCanonicalQueryString(url) {
   var parser = document.createElement('a');
@@ -279,6 +277,7 @@ function getCanonicalQueryString(url) {
   for (var i=0; i<params.length; i++) {
 	  if (params[i].substr(0,1) === '?')
         params[i] = params[i].substr(1, params[i].length-1);
+      params[i] = params[i].split('=').map(decodeURIComponent).map(uriEncode).join('=');
   }
 
   var sortedParams = params.sort();
@@ -338,5 +337,19 @@ function getHashedPayload(request) {
 function log(msg) {
   console.log( msg);
 }
+function uriEncode(input) {
+  var ch;
+  var i;
+  var output = '';
+  for (i = 0; i < input.length; i++) {
+    ch = input[i];
+    if ((ch >= 'A' && ch <= 'Z') || (ch >= 'a' && ch <= 'z') || (ch >= '0' && ch <= '9') || ch === '_' || ch === '-' || ch === '~' || ch === '.' || ch === '/') {
+      output += ch;
+    } else {
+      output += `%${ch.charCodeAt(0).toString(16).toUpperCase()}`;
+    }
+  }
+  return output;
+};
 
 getsettings();

--- a/src/signer.js
+++ b/src/signer.js
@@ -277,7 +277,7 @@ function getCanonicalQueryString(url) {
   for (var i=0; i<params.length; i++) {
 	  if (params[i].substr(0,1) === '?')
         params[i] = params[i].substr(1, params[i].length-1);
-      params[i] = params[i].split('=').map(decodeURIComponent).map(uriEncode).join('=');
+      params[i] = params[i].split('=').map(decodeURIComponent).map(uriEncodeSlash).join('=');
   }
 
   var sortedParams = params.sort();
@@ -337,13 +337,16 @@ function getHashedPayload(request) {
 function log(msg) {
   console.log( msg);
 }
-function uriEncode(input) {
+function uriEncodeSlash(input) {
+	return uriEncode(input, true)
+}
+function uriEncode(input, slash) {
   var ch;
   var i;
   var output = '';
   for (i = 0; i < input.length; i++) {
     ch = input[i];
-    if ((ch >= 'A' && ch <= 'Z') || (ch >= 'a' && ch <= 'z') || (ch >= '0' && ch <= '9') || ch === '_' || ch === '-' || ch === '~' || ch === '.' || ch === '/') {
+    if ((ch >= 'A' && ch <= 'Z') || (ch >= 'a' && ch <= 'z') || (ch >= '0' && ch <= '9') || ch === '_' || ch === '-' || ch === '~' || ch === '.' || (!slash && ch === '/')) {
       output += ch;
     } else {
       output += `%${ch.charCodeAt(0).toString(16).toUpperCase()}`;


### PR DESCRIPTION
Per http://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-query-string-auth.html#query-string-auth-v4-signing

Ran into an issue with AWS ES where CanonicalURI and co. needed a few more characters encoded than there was. This patch resolves it but I haven't tested it anywhere else and it probably could use some linting but I didn't want to push my eslint config's opinions on others. Let me know if any changes are needed.