### PR TITLE
Do more complete normalization of URIs & headers

### DIFF
--- a/src/signer.js
+++ b/src/signer.js
@@ -267,7 +267,7 @@ function getCanonicalUri(url) {
   var stack = [],
       parts = uri.split('/');
   for (var i=0; i<parts.length; i++) {
-    if (parts[i] === '.' || parts[i].length === 0)
+    if (parts[i] === '.' || (parts[i].length === 0 && i+1<parts.length))
       continue;
     if (parts[i] === '..')
       stack.pop();


### PR DESCRIPTION
This is an attempt to implement more of AWS's canonicalization rules that are part of their signing algorithm. In particular (among other things) it addresses some specific problems I've run across:
 - `/foo//bar` (needs to be canonicalized to `/foo/bar`)
 - `/_cat/shards?v` (needs to be `/_cat/shards?v=`)
 - `/_plugin/kibana/api/kibana/settings/discover:aggs:terms:size` (needs to be `/_plugin/kibana/api/kibana/settings/discover%3Aaggs%3Aterms%3Asize`)